### PR TITLE
py-language-server: update to 0.23.2

### DIFF
--- a/python/py-language-server/Portfile
+++ b/python/py-language-server/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 PortGroup           select 1.0
 
-github.setup        palantir python-language-server 0.22.1
+github.setup        palantir python-language-server 0.23.2
 revision            0
 name                py-language-server
 categories-append   devel
@@ -17,9 +17,9 @@ long_description    ${description}
 platforms           darwin
 supported_archs     noarch
 
-checksums           rmd160  e2ba3892af6792633c85e85ba38a293d57d8b4b3 \
-                    sha256  3775928b858ca96932c54b1d0437f61eca4974364c881c32427d29dd132f0574 \
-                    size    440432
+checksums           rmd160  f1656749ad0260f484f9098505d401d1746f12c3 \
+                    sha256  af8f5573009e70d1e3314b196b412ee7ebdf8ba637b81ccd51ebb5c9ab0f1956 \
+                    size    440961
 
 python.versions     27 35 36 37
 


### PR DESCRIPTION
Update py-language-server to 0.23.2

###### Tested on
macOS 10.14.3 18D42
Xcode 10.1 10B61


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->